### PR TITLE
Keep quic protocol headers only between one hop

### DIFF
--- a/caddyhttp/proxy/reverseproxy.go
+++ b/caddyhttp/proxy/reverseproxy.go
@@ -271,6 +271,8 @@ var hopHeaders = []string{
 	"Trailers",
 	"Transfer-Encoding",
 	"Upgrade",
+	"Alternate-Protocol",
+	"Alt-Svc",
 }
 
 type respUpdateFn func(resp *http.Response)


### PR DESCRIPTION
Removing quic protocol headers from being persisted during proxy requests.
Not removing them could lead to the client attempting to connect to the wrong port.
This makes the quic headers consistent with other protocol headers.